### PR TITLE
fixed bad behavior when running shell commands in background

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshClient.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshClient.java
@@ -233,7 +233,7 @@ public class BapSshClient extends BPDefaultClient<BapTransfer> {
         if (waiter.isAlive()) {
             waiter.interrupt();
         }
-        if (!exec.isClosed())
+        if (!(exec.isClosed() || exec.isEOF() || exec.getExitStatus() >= 0) )
             throw new BapPublisherException(Messages.exception_exec_timeout(duration));
         buildInfo.println(Messages.console_exec_completed(duration));
     }

--- a/src/test/java/jenkins/plugins/publish_over_ssh/BapSshClientTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/BapSshClientTest.java
@@ -318,6 +318,8 @@ public class BapSshClientTest {
             assertEquals(expectedTimeout, timeout);
         }
         public int getExitStatus() {
+            if(!isClosed())
+                return -1;
             return exitStatus;
         }
         public void assertMethodsCalled() {


### PR DESCRIPTION
before patch you always got timed out when you run something like:
"nohup start-my-demon-server-stuff.sh &"

behavoir now is:
"sleep 10"
returns after 10 sec
"sleep 10 &"
returns immediately 

ps. please review the test changes not quite sure whether I got them right.

Thanks,
Edmund
