### PR TITLE
configure jsch to disable interactive authentication

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration.java
@@ -230,7 +230,10 @@ public class BapSshHostConfiguration extends BPHostConfiguration<BapSshClient, B
         final String username = overrideCreds == null ? getUsername() : overrideCreds.getUsername();
         try {
             buildInfo.printIfVerbose(Messages.console_session_creating(username, getHostnameTrimmed(), getPort()));
-            return ssh.getSession(username, getHostnameTrimmed(), getPort());
+            Session session = ssh.getSession(username, getHostnameTrimmed(), getPort());
+            // disable gssapi-with-mic and keyboard-interactive that would require user interaction
+            session.setConfig("PreferredAuthentications", "publickey,password");
+            return session;
         } catch (JSchException jse) {
             throw new BapPublisherException(Messages.exception_session_create(
                     username, getHostnameTrimmed(), getPort(), jse.getLocalizedMessage()), jse);


### PR DESCRIPTION
jsch is by default configured with a set of authentication strategies, some of them require user interaction. By definition, jenkins jobs are non-interactive and can't use them, so authentication may better fail than showing a login prompt on console and fail on timeout. 
