### PR TITLE
Updated jsch to 0.1.51 (JENKINS-19811)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.45</version>
+            <version>0.1.51</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Updated the jsch dependency to 0.1.51 to fix JENKINS-19811:
https://issues.jenkins-ci.org/browse/JENKINS-19811

jsch < 0.1.50 has compatibility problems with Java 7.