### PR TITLE
Inject ssh credentials

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
@@ -39,10 +39,17 @@ public class BapSshCredentials extends BapSshKeyInfo implements Credentials<BapS
 
     private final String username;
 
+    private final boolean injectCredentials;
+
     @DataBoundConstructor
-    public BapSshCredentials(final String username, final String encryptedPassphrase, final String key, final String keyPath) {
+    public BapSshCredentials(final String username, final String encryptedPassphrase, final String key, final String keyPath, boolean injectCredentials) {
         super(encryptedPassphrase, key, keyPath);
         this.username = username;
+        this.injectCredentials = injectCredentials;
+    }
+
+    public Boolean getInjectCredentials() {
+        return injectCredentials;
     }
 
     public String getUsername() {
@@ -55,17 +62,20 @@ public class BapSshCredentials extends BapSshKeyInfo implements Credentials<BapS
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshCredentials that) {
         return super.addToEquals(builder, that)
-            .append(username, that.username);
+            .append(username, that.username)
+            .append(injectCredentials, that.injectCredentials);
     }
 
     protected HashCodeBuilder addToHashCode(final HashCodeBuilder builder) {
         return super.addToHashCode(builder)
-            .append(username);
+            .append(username)
+            .append(injectCredentials);
     }
 
     protected ToStringBuilder addToToString(final ToStringBuilder builder) {
         return super.addToToString(builder)
-            .append("username", username);
+            .append("username", username)
+            .append("injectCredentials", injectCredentials);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshCredentialsDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshCredentialsDescriptor.java
@@ -74,8 +74,8 @@ public class BapSshCredentialsDescriptor extends Descriptor<BapSshCredentials> {
 
     public FormValidation doTestConnection(@QueryParameter final String configName, @QueryParameter final String username,
                                            @QueryParameter final String encryptedPassphrase, @QueryParameter final String key,
-                                           @QueryParameter final String keyPath) {
-        final BapSshCredentials credentials = new BapSshCredentials(username, encryptedPassphrase, key, keyPath);
+                                           @QueryParameter final String keyPath, @QueryParameter final Boolean injectCredentials) {
+        final BapSshCredentials credentials = new BapSshCredentials(username, encryptedPassphrase, key, keyPath, injectCredentials);
         final BPBuildInfo buildInfo = BapSshPublisherPluginDescriptor.createDummyBuildInfo();
         buildInfo.put(BPBuildInfo.OVERRIDE_CREDENTIALS_CONTEXT_KEY, credentials);
         final BapSshPublisherPlugin.Descriptor pluginDescriptor = Hudson.getInstance().getDescriptorByType(

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshCredentials/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshCredentials/config.properties
@@ -23,6 +23,7 @@
 #
 
 username=Username
+injectCredentials=Inject credentials
 passphrase=Passphrase / Password
 keyPath=Path to key
 key=Key

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshCredentials/config_no_BV.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshCredentials/config_no_BV.properties
@@ -23,6 +23,7 @@
 #
 
 username=U*e*n*m*
+injectCredentials=I*j*c*a*l*
 passphrase=P*s*p*r*s* / P*s*w*r*
 keyPath=P*t* t* k*y
 key=K*y

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshCredentials/help-injectCredentials.html
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshCredentials/help-injectCredentials.html
@@ -1,5 +1,3 @@
-<?jelly escape-by-default='true'?>
-
 <!--
   ~ The MIT License
   ~
@@ -24,25 +22,4 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:poj="/pojelly">
-
-    <poj:defaultMessages/>
-
-    <f:entry title="${%injectCredentials}" field="injectCredentials">
-       <f:checkbox/>
-    </f:entry>
-    <f:entry title="${%username}" field="username">
-        <f:textbox/>
-    </f:entry>
-    <f:entry title="${%passphrase}" field="encryptedPassphrase">
-        <f:password/>
-    </f:entry>
-    <f:entry title="${%keyPath}" field="keyPath">
-        <f:textbox/>
-    </f:entry>
-    <f:entry title="${%key}" field="key">
-        <f:textarea/>
-    </f:entry>
-    <f:validateButton title="${m.test_title()}" progress="${m.test_progress()}" method="testConnection"
-                            with="configName,username,encryptedPassphrase,keyPath,key"/>
-</j:jelly>
+<div>If checked, the username and password fields should be environment variable names that will be injected</div>


### PR DESCRIPTION
This pull request adds a checkbox called "Inject credentials" that allows you to specify an environment variable in the ssh username and password fields rather than the actual username password. The credentials can then be injected through the parameterized build plugin. This provides a way of not caching credentials in Jenkins and requires explicit username/password for SSH operations on specific servers if desired.

I didn't see a specific JIRA request for this, but the idea of injecting values in this plugin was mentioned in a few different issues. This was something I have been working on internally and wanted to open source it.
