### PR TITLE
[FIXED JENKINS-29360] Updated jsch to 0.1.53

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.45</version>
+            <version>0.1.53</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This fixes the "Algorithm negotiation failed" error when the SSH server is configured with more secure key exchange/cipher algorithms. See https://issues.jenkins-ci.org/browse/JENKINS-29360