### PR TITLE
Upgrade to JSCH 0.1.53 (JENKINS-29999)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.45</version>
+            <version>0.1.53</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -216,7 +216,7 @@
                         <artifactId>maven-pmd-plugin</artifactId>
                         <version>2.5</version>
                         <configuration>
-                            <targetJdk>1.5</targetJdk>
+                            <targetJdk>1.7</targetJdk>
                             <includeTests>true</includeTests>
                             <rulesets>
                                 <ruleset>src/metrics/pmd_rules.xml</ruleset>


### PR DESCRIPTION
It's a quick pull request to use latest JSCH that fix connections with stronger key exchange, MACs and ciphers.
JDK version for PMD upgraded to JDK 7.