### PR TITLE
Fix:SSH Key Path not taking from the Job param

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshKeyInfo.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshKeyInfo.java
@@ -66,13 +66,7 @@ public class BapSshKeyInfo implements Serializable {
     public byte[] getEffectiveKey(final BPBuildInfo buildInfo) {
         if (hasKey())
             return BapSshUtil.toBytes(key);
-        
-        
-        
         keyPath = Util.replaceMacro(keyPath, buildInfo.getEnvVars());
-        
-      
-        
         return buildInfo.readFileFromMaster(keyPath.trim());
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshKeyInfo.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshKeyInfo.java
@@ -66,6 +66,13 @@ public class BapSshKeyInfo implements Serializable {
     public byte[] getEffectiveKey(final BPBuildInfo buildInfo) {
         if (hasKey())
             return BapSshUtil.toBytes(key);
+        
+        System.out.println("IDP : Attempting to resolve JOB PARAMETERS for " + keyPath);
+        
+        keyPath = Util.replaceMacro(keyPath, buildInfo.getEnvVars());
+        
+        System.out.println("IDP : Resolved keyPath is " + keyPath);
+        
         return buildInfo.readFileFromMaster(keyPath.trim());
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshKeyInfo.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshKeyInfo.java
@@ -67,11 +67,11 @@ public class BapSshKeyInfo implements Serializable {
         if (hasKey())
             return BapSshUtil.toBytes(key);
         
-        System.out.println("IDP : Attempting to resolve JOB PARAMETERS for " + keyPath);
+        
         
         keyPath = Util.replaceMacro(keyPath, buildInfo.getEnvVars());
         
-        System.out.println("IDP : Resolved keyPath is " + keyPath);
+      
         
         return buildInfo.readFileFromMaster(keyPath.trim());
     }


### PR DESCRIPTION
SSH Key path was not taken from job param value. Now its working fine, SSH Key Path can be job param as well. 