### PR TITLE
[JENKINS-48920] - Make the plugin compatible with JEP-200

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin()

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ send artifacts to an SSH server (using SFTP) and/or execute commands over SSH
 
 For more information, visit the wiki page:
 
-https://wiki.jenkins-ci.org/display/JENKINS/Publish+Over+SSH+Plugin
+https://wiki.jenkins.io/display/JENKINS/Publish+Over+SSH+Plugin

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.19</version>
+        <version>3.2</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -43,7 +43,8 @@
 
     <properties>
         <java.net.id>bap</java.net.id>
-	<jenkins.version>1.580.1</jenkins.version>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
@@ -72,13 +73,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>publish-over</artifactId>
-            <version>0.18</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.9</version>
-            <scope>test</scope>
+            <version>0.21</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -98,16 +93,9 @@
             <version>2.4</version>
             <scope>test</scope>
         </dependency>
-	<dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-war</artifactId>
-            <type>war</type>
-            <version>${jenkins.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
@@ -129,21 +117,6 @@
     <build>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.12.4</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>1.1</version>
-				</plugin>
     				<plugin>
         				<groupId>org.apache.maven.plugins</groupId>
         				<artifactId>maven-release-plugin</artifactId>
@@ -162,7 +135,6 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <!--  <version>1.67</version> -->
                 <extensions>true</extensions>
                 <configuration>
                     <compatibleSinceVersion>0.3</compatibleSinceVersion>
@@ -171,7 +143,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<!--  <version>1.7</version> -->
 				<executions>
 					<execution>
 						<id>add-eclipse-sources</id>
@@ -255,14 +226,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.53</version>
+            <version>0.1.54.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshAlwaysRunPublisherPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshAlwaysRunPublisherPlugin.java
@@ -26,6 +26,7 @@ package jenkins.plugins.publish_over_ssh;
 
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Run;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -47,7 +48,7 @@ public class BapSshAlwaysRunPublisherPlugin extends BapSshPublisherPlugin {
     }
 
     @Override
-    protected boolean isBuildGoodEnoughToRun(final AbstractBuild<?, ?> build, final PrintStream console) {
+    protected boolean isBuildGoodEnoughToRun(final Run<?, ?> build, final PrintStream console) {
         return true;
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshBuilderPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshBuilderPlugin.java
@@ -32,6 +32,7 @@ import hudson.model.BuildListener;
 import hudson.model.Hudson;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPPlugin;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -100,7 +101,7 @@ public class BapSshBuilderPlugin extends Builder {
             return Messages.builder_descriptor_displayName();
         }
         public BapSshPublisherPlugin.Descriptor getPublisherDescriptor() {
-            return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+            return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCommonConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCommonConfiguration.java
@@ -26,6 +26,7 @@ package jenkins.plugins.publish_over_ssh;
 
 import hudson.model.Describable;
 import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over_ssh.descriptor.BapSshCommonConfigurationDescriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -51,7 +52,7 @@ public class BapSshCommonConfiguration extends BapSshKeyInfo implements Describa
     }
 
     public BapSshCommonConfigurationDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshCommonConfigurationDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshCommonConfigurationDescriptor.class);
     }
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshCommonConfiguration that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
@@ -25,6 +25,7 @@
 package jenkins.plugins.publish_over_ssh;
 
 import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.Credentials;
 import jenkins.plugins.publish_over_ssh.descriptor.BapSshCredentialsDescriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -50,7 +51,7 @@ public class BapSshCredentials extends BapSshKeyInfo implements Credentials<BapS
     }
 
     public BapSshCredentialsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshCredentialsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshCredentialsDescriptor.class);
     }
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshCredentials that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Properties;
 
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.*;
 import jenkins.plugins.publish_over_ssh.descriptor.BapSshHostConfigurationDescriptor;
 import org.apache.commons.lang.StringUtils;
@@ -434,7 +435,7 @@ public class BapSshHostConfiguration extends BPHostConfiguration<BapSshClient, B
     }
 
     public BapSshHostConfigurationDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshHostConfigurationDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshHostConfigurationDescriptor.class);
     }
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshHostConfiguration that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshParamPublish.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshParamPublish.java
@@ -27,7 +27,7 @@ package jenkins.plugins.publish_over_ssh;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.ParamPublish;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -45,7 +45,7 @@ public class BapSshParamPublish extends ParamPublish implements Describable<BapS
     }
 
     public BapSshParamPublishDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshParamPublishDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshParamPublishDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPostBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPostBuildWrapper.java
@@ -29,9 +29,9 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.model.Hudson;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -106,7 +106,7 @@ public class BapSshPostBuildWrapper extends BuildWrapper {
             return Messages.postBuild_descriptor_displayName();
         }
         public BapSshPublisherPlugin.Descriptor getPublisherDescriptor() {
-            return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+            return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPreBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPreBuildWrapper.java
@@ -29,9 +29,9 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.model.Hudson;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -100,7 +100,7 @@ public class BapSshPreBuildWrapper extends BuildWrapper {
             return Messages.preBuild_descriptor_displayName();
         }
         public BapSshPublisherPlugin.Descriptor getPublisherDescriptor() {
-            return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+            return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPromotionPublisherPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPromotionPublisherPlugin.java
@@ -29,11 +29,11 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.model.Hudson;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPPlugin;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -107,7 +107,7 @@ public class BapSshPromotionPublisherPlugin extends Notifier {
             return Messages.promotion_descriptor_displayName();
         }
         public BapSshPublisherPlugin.Descriptor getPublisherDescriptor() {
-            return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+            return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisher.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisher.java
@@ -26,6 +26,7 @@ package jenkins.plugins.publish_over_ssh;
 
 import hudson.model.Describable;
 import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BapPublisher;
 import jenkins.plugins.publish_over_ssh.descriptor.BapSshPublisherDescriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -71,7 +72,7 @@ public class BapSshPublisher extends BapPublisher<BapSshTransfer> implements Des
     }
 
     public BapSshPublisherDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshPublisherDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisherLabel.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisherLabel.java
@@ -27,7 +27,7 @@ package jenkins.plugins.publish_over_ssh;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.PublisherLabel;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -45,7 +45,7 @@ public class BapSshPublisherLabel extends PublisherLabel implements Describable<
     }
 
     public BapSshPublisherLabelDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshPublisherLabelDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherLabelDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisherPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisherPlugin.java
@@ -27,6 +27,8 @@ package jenkins.plugins.publish_over_ssh;
 import hudson.Extension;
 import hudson.model.Hudson;
 import java.util.ArrayList;
+
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPPlugin;
 import jenkins.plugins.publish_over.BPPluginDescriptor;
 import jenkins.plugins.publish_over_ssh.descriptor.BapSshPublisherPluginDescriptor;
@@ -74,7 +76,7 @@ public class BapSshPublisherPlugin extends BPPlugin<BapSshPublisher, BapSshClien
 
     @Override
     public Descriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(Descriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(Descriptor.class);
     }
 
     public BapSshHostConfiguration getConfiguration(final String name) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshRetry.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshRetry.java
@@ -27,8 +27,8 @@ package jenkins.plugins.publish_over_ssh;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.Retry;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -47,7 +47,7 @@ public class BapSshRetry extends Retry implements Describable<BapSshRetry> {
     }
 
     public BapSshRetryDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshRetryDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshRetryDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransfer.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransfer.java
@@ -26,7 +26,7 @@ package jenkins.plugins.publish_over_ssh;
 
 import hudson.Util;
 import hudson.model.Describable;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPTransfer;
 import jenkins.plugins.publish_over_ssh.descriptor.BapSshTransferDescriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -86,7 +86,7 @@ public class BapSshTransfer extends BPTransfer implements Describable<BapSshTran
     }
 
     public BapSshTransferDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshTransferDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshTransferDescriptor.class);
     }
 
     protected HashCodeBuilder addToHashCode(final HashCodeBuilder builder) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshCredentialsDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshCredentialsDescriptor.java
@@ -27,7 +27,6 @@ package jenkins.plugins.publish_over_ssh.descriptor;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
@@ -80,7 +79,7 @@ public class BapSshCredentialsDescriptor extends Descriptor<BapSshCredentials> {
         final BapSshCredentials credentials = new BapSshCredentials(username, encryptedPassphrase, key, keyPath);
         final BPBuildInfo buildInfo = BapSshPublisherPluginDescriptor.createDummyBuildInfo();
         buildInfo.put(BPBuildInfo.OVERRIDE_CREDENTIALS_CONTEXT_KEY, credentials);
-        final BapSshPublisherPlugin.Descriptor pluginDescriptor = Hudson.getInstance().getDescriptorByType(
+        final BapSshPublisherPlugin.Descriptor pluginDescriptor = Jenkins.getActiveInstance().getDescriptorByType(
                                                                                                     BapSshPublisherPlugin.Descriptor.class);
         final BapSshHostConfiguration hostConfig = pluginDescriptor.getConfiguration(configName);
         return BapSshPublisherPluginDescriptor.validateConnection(hostConfig, buildInfo);

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshHostConfigurationDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshHostConfigurationDescriptor.java
@@ -26,8 +26,8 @@ package jenkins.plugins.publish_over_ssh.descriptor;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPValidators;
 import jenkins.plugins.publish_over_ssh.BapSshHostConfiguration;
 import jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin;
@@ -85,7 +85,7 @@ public class BapSshHostConfigurationDescriptor extends Descriptor<BapSshHostConf
     }
 
     public FormValidation doTestConnection(final StaplerRequest request, final StaplerResponse response) {
-        final BapSshPublisherPlugin.Descriptor pluginDescriptor = Hudson.getInstance().getDescriptorByType(
+        final BapSshPublisherPlugin.Descriptor pluginDescriptor = Jenkins.getActiveInstance().getDescriptorByType(
                 BapSshPublisherPlugin.Descriptor.class);
         return pluginDescriptor.doTestConnection(request, response);
     }

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshPublisherDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshPublisherDescriptor.java
@@ -26,7 +26,7 @@ package jenkins.plugins.publish_over_ssh.descriptor;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over_ssh.BapSshPublisher;
 import jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin;
 import jenkins.plugins.publish_over_ssh.Messages;
@@ -44,11 +44,11 @@ public class BapSshPublisherDescriptor extends Descriptor<BapSshPublisher> {
     }
 
     public BapSshPublisherPlugin.Descriptor getPublisherPluginDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
     }
 
     public BapSshTransferDescriptor getTransferDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshTransferDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshTransferDescriptor.class);
     }
 
     public jenkins.plugins.publish_over.view_defaults.BapPublisher.Messages getCommonFieldNames() {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshPublisherPluginDescriptor.java
@@ -27,12 +27,12 @@ package jenkins.plugins.publish_over_ssh.descriptor;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import hudson.model.AbstractProject;
-import hudson.model.Hudson;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import hudson.util.CopyOnWriteList;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPBuildInfo;
 import jenkins.plugins.publish_over.BPInstanceConfig;
 import jenkins.plugins.publish_over.BPPlugin;
@@ -151,15 +151,15 @@ public class BapSshPublisherPluginDescriptor extends BuildStepDescriptor<Publish
     }
 
     public BapSshPublisherDescriptor getPublisherDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshPublisherDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherDescriptor.class);
     }
 
     public BapSshHostConfigurationDescriptor getHostConfigurationDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshHostConfigurationDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshHostConfigurationDescriptor.class);
     }
 
     public SshPluginDefaults.SshPluginDefaultsDescriptor getPluginDefaultsDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshPluginDefaults.SshPluginDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshPluginDefaults.SshPluginDefaultsDescriptor.class);
     }
 
     public jenkins.plugins.publish_over.view_defaults.BPInstanceConfig.Messages getCommonFieldNames() {
@@ -198,7 +198,7 @@ public class BapSshPublisherPluginDescriptor extends BuildStepDescriptor<Publish
         return new BPBuildInfo(
             TaskListener.NULL,
             "",
-            Hudson.getInstance().getRootPath(),
+            Jenkins.getActiveInstance().getRootPath(),
             null,
             null
         );

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshTransferDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshTransferDescriptor.java
@@ -27,8 +27,8 @@ package jenkins.plugins.publish_over_ssh.descriptor;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPTransfer;
 import jenkins.plugins.publish_over.BPValidators;
 import jenkins.plugins.publish_over_ssh.BapSshHostConfiguration;
@@ -56,7 +56,7 @@ public class BapSshTransferDescriptor extends Descriptor<BapSshTransfer> {
     public FormValidation doCheckSourceFiles(@QueryParameter final String configName, @QueryParameter final String sourceFiles,
                                              @QueryParameter final String execCommand) {
         if (Util.fixEmptyAndTrim(configName) != null) {
-            final BapSshPublisherPlugin.Descriptor pluginDescriptor = Hudson.getInstance().getDescriptorByType(
+            final BapSshPublisherPlugin.Descriptor pluginDescriptor = Jenkins.getActiveInstance().getDescriptorByType(
                     BapSshPublisherPlugin.Descriptor.class);
             final BapSshHostConfiguration hostConfig = pluginDescriptor.getConfiguration(configName);
             if (hostConfig == null)

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshDefaults.java
@@ -29,15 +29,16 @@ import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 
 public abstract class SshDefaults implements Describable<SshDefaults>, ExtensionPoint, SshOptions {
 
     public static DescriptorExtensionList<SshDefaults, SshDefaultsDescriptor> all() {
-        return Hudson.getInstance().<SshDefaults, SshDefaultsDescriptor>getDescriptorList(SshDefaults.class);
+        return Jenkins.getActiveInstance().getDescriptorList(SshDefaults.class);
     }
 
     public SshDefaultsDescriptor getDescriptor() {
-        return (SshDefaultsDescriptor) Hudson.getInstance().getDescriptor(getClass());
+        return (SshDefaultsDescriptor) Jenkins.getActiveInstance().getDescriptor(getClass());
     }
 
     public abstract static class SshDefaultsDescriptor extends Descriptor<SshDefaults> {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideInstanceConfigDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideInstanceConfigDefaults.java
@@ -27,7 +27,7 @@ package jenkins.plugins.publish_over_ssh.options;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.options.InstanceConfigOptions;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -58,7 +58,7 @@ public class SshOverrideInstanceConfigDefaults implements InstanceConfigOptions,
     }
 
     public SshOverrideInstanceConfigDefaultsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshOverrideInstanceConfigDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshOverrideInstanceConfigDefaultsDescriptor.class);
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideParamPublishDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideParamPublishDefaults.java
@@ -27,7 +27,7 @@ package jenkins.plugins.publish_over_ssh.options;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.options.ParamPublishOptions;
 import jenkins.plugins.publish_over_ssh.BapSshParamPublish;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -46,7 +46,7 @@ public class SshOverrideParamPublishDefaults implements ParamPublishOptions, Des
     }
 
     public SshOverrideParamPublishDefaultsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshOverrideParamPublishDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshOverrideParamPublishDefaultsDescriptor.class);
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverridePublisherDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverridePublisherDefaults.java
@@ -27,7 +27,7 @@ package jenkins.plugins.publish_over_ssh.options;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.options.PublisherOptions;
 import jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -65,7 +65,7 @@ public class SshOverridePublisherDefaults implements PublisherOptions, Describab
     }
 
     public SshOverridePublisherDefaultsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshOverridePublisherDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshOverridePublisherDefaultsDescriptor.class);
     }
 
     @Extension
@@ -77,7 +77,7 @@ public class SshOverridePublisherDefaults implements PublisherOptions, Describab
         }
 
         public BapSshPublisherPlugin.Descriptor getPublisherPluginDescriptor() {
-            return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+            return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
         }
 
         public jenkins.plugins.publish_over.view_defaults.BapPublisher.Messages getCommonFieldNames() {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverridePublisherLabelDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverridePublisherLabelDefaults.java
@@ -27,7 +27,7 @@ package jenkins.plugins.publish_over_ssh.options;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.options.PublisherLabelOptions;
 import jenkins.plugins.publish_over_ssh.BapSshPublisherLabel;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -46,7 +46,7 @@ public class SshOverridePublisherLabelDefaults implements PublisherLabelOptions,
     }
 
     public SshOverridePublisherLabelDefaultsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshOverridePublisherLabelDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshOverridePublisherLabelDefaultsDescriptor.class);
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideRetryDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideRetryDefaults.java
@@ -27,8 +27,8 @@ package jenkins.plugins.publish_over_ssh.options;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.options.RetryOptions;
 import jenkins.plugins.publish_over_ssh.BapSshRetry;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -54,7 +54,7 @@ public class SshOverrideRetryDefaults implements RetryOptions, Describable<SshOv
     }
 
     public SshOverrideRetryDefaultsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshOverrideRetryDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshOverrideRetryDefaultsDescriptor.class);
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults.java
@@ -27,8 +27,8 @@ package jenkins.plugins.publish_over_ssh.options;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPTransfer;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -111,7 +111,7 @@ public class SshOverrideTransferDefaults implements SshTransferOptions, Describa
     }
 
     public SshOverrideTransferDefaultsDescriptor getDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(SshOverrideTransferDefaultsDescriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(SshOverrideTransferDefaultsDescriptor.class);
     }
 
     public boolean isUsePty() {

--- a/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/JenkinsTestHelper.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/JenkinsTestHelper.java
@@ -24,8 +24,8 @@
 
 package jenkins.plugins.publish_over_ssh.jenkins;
 
-import hudson.model.Hudson;
 import hudson.util.CopyOnWriteList;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over_ssh.BapSshCommonConfiguration;
 import jenkins.plugins.publish_over_ssh.BapSshHostConfiguration;
 import jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin;
@@ -80,7 +80,7 @@ public class JenkinsTestHelper {
         }
         final CopyOnWriteList<BapSshHostConfiguration> hostConfigurations = getHostConfigurations();
         hostConfigurations.replaceBy(newHostConfigurations);
-        Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class).setCommonConfig(commonConfig);
+        Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class).setCommonConfig(commonConfig);
     }
 
     public CopyOnWriteList<BapSshHostConfiguration> getHostConfigurations() throws NoSuchFieldException, IllegalAccessException {
@@ -99,7 +99,7 @@ public class JenkinsTestHelper {
         }
         public CopyOnWriteList<BapSshHostConfiguration> run() throws IllegalAccessException {
             hostConfigurations.setAccessible(true);
-            return (CopyOnWriteList) hostConfigurations.get(Hudson.getInstance().getDescriptorByType(
+            return (CopyOnWriteList) hostConfigurations.get(Jenkins.getActiveInstance().getDescriptorByType(
                                                             BapSshPublisherPlugin.Descriptor.class));
         }
     }

--- a/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/LegacyConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/LegacyConfigurationTest.java
@@ -29,6 +29,7 @@ import hudson.model.Hudson;
 import hudson.model.Project;
 import hudson.tasks.BuildWrapper;
 import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over_ssh.BapSshBuilderPlugin;
 import jenkins.plugins.publish_over_ssh.BapSshCommonConfiguration;
 import jenkins.plugins.publish_over_ssh.BapSshHostConfiguration;
@@ -209,7 +210,7 @@ public class LegacyConfigurationTest extends HudsonTestCase {
             + "-----END DSA PRIVATE KEY-----\n";
 
     private BapSshPublisherPlugin.Descriptor getPublisherPluginDescriptor() {
-        return Hudson.getInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
+        return Jenkins.getActiveInstance().getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
     }
     private BapSshPublisherPlugin getConfiguredPublisherPlugin() {
         for (Project project : hudson.getProjects()) {


### PR DESCRIPTION
- [x] Use "Infrastructure plugin for Publish Over X" plugin (pluginized by https://github.com/jenkinsci/publish-over-plugin/pull/8). Repackaging the lib to the plugin should have resolved class serialization issues
- [x] Update Jenkins core requirement to 1.625.3, use the latest Plugin POM
- [x] Use JSch plugin instead of bundling own JSch version
- [x] Add Jenkinsfile

https://issues.jenkins-ci.org/browse/JENKINS-48920

@reviewbybees @jglick @slide 