### PR TITLE
Fix misconfigured url path in <scm> block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     </dependencies>
 
     <scm>
-        <url>https://github.com/jenkinsci/publish-over-ftp-plugin</url>
+        <url>https://github.com/jenkinsci/publish-over-ssh-plugin</url>
         <connection>scm:git:git://github.com/jenkinsci/publish-over-ssh-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/publish-over-ssh-plugin.git</developerConnection>
       <tag>publish-over-ssh-1.15</tag>


### PR DESCRIPTION
Just notify that the hyperlink of the **GitHub →** link on the left-top corner of the [Jenkins Plugins - Publish Over SSH](https://plugins.jenkins.io/publish-over-ssh) is misconfigured as **publish-over-ftp-plugin**, and found out that the pom.xml is wrong too.