### PR TITLE
[JENKINS-53437] Some fixes for SFTP protocol implementation for Exec commands

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransfer.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransfer.java
@@ -124,7 +124,7 @@ public class BapSshTransfer extends BPTransfer implements Describable<BapSshTran
     }
 
     protected HashCodeBuilder addToHashCode(final HashCodeBuilder builder) {
-        return super.addToHashCode(builder).append(execCommand).append(execTimeout).append(usePty).append(useAgentForwarding);
+        return super.addToHashCode(builder).append(execCommand).append(execTimeout).append(usePty).append(useAgentForwarding).append(useSftpForExec);
     }
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshTransfer that) {
@@ -132,7 +132,8 @@ public class BapSshTransfer extends BPTransfer implements Describable<BapSshTran
                 .append(execCommand, that.execCommand)
                 .append(execTimeout, that.execTimeout)
                 .append(usePty, that.usePty)
-                .append(useAgentForwarding, that.useAgentForwarding);
+                .append(useAgentForwarding, that.useAgentForwarding)
+                .append(useSftpForExec, that.useSftpForExec);
     }
 
     protected ToStringBuilder addToToString(final ToStringBuilder builder) {
@@ -140,7 +141,8 @@ public class BapSshTransfer extends BPTransfer implements Describable<BapSshTran
                 .append("execCommand", execCommand)
                 .append("execTimeout", execTimeout)
                 .append("pseudoTty", usePty)
-                .append("agentForwarding", useAgentForwarding);
+                .append("agentForwarding", useAgentForwarding)
+                .append("useSftpForExec", useSftpForExec);
     }
 
     public boolean equals(final Object that) {

--- a/src/test/java/jenkins/plugins/publish_over_ssh/SftpForExecTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/SftpForExecTest.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 
 
-public class sftpForExecTest {
+public class SftpForExecTest {
 
 private final IMocksControl mockControl = EasyMock.createStrictControl();
 private final Session mockSession = mockControl.createMock(Session.class);


### PR DESCRIPTION
Hello!
There are some fixes for SFTP protocol implementation for Exec commands:

1. Information about useSftpForExec was added to "addToHashCode", "addToEquals" and "addToToString" methods.

2. sftpForExecTest class was renamed to SftpForExecTest

Regards,
Alexander