### PR TITLE
[JENKINS-67963] Add option to save bandwidth and resources, which are wasted unnecessarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,15 +50,12 @@
     <gitHubRepo>jenkinsci/publish-over-ssh-plugin</gitHubRepo>
     <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
-
-    <timestamp>${maven.build.timestamp}</timestamp>
-    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
   </properties>
 
   <artifactId>publish-over-ssh</artifactId>
     <packaging>hpi</packaging>
     <name>Publish Over SSH</name>
-    <version>${revision}${changelist}-JENKINS67693-${timestamp}</version>
+    <version>${revision}${changelist}</version>
     <description>Send build artifacts over SSH</description>
     <url>https://github.com/jenkinsci/publish-over-ssh-plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,18 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -32,20 +44,23 @@
         <version>4.19</version>
     </parent>
 
-    <artifactId>publish-over-ssh</artifactId>
+  <properties>
+    <revision>1.25</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/publish-over-ssh-plugin</gitHubRepo>
+    <jenkins.version>2.289.1</jenkins.version>
+    <java.level>8</java.level>
+
+    <timestamp>${maven.build.timestamp}</timestamp>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+  </properties>
+
+  <artifactId>publish-over-ssh</artifactId>
     <packaging>hpi</packaging>
     <name>Publish Over SSH</name>
-    <version>${revision}${changelist}</version>
+    <version>${revision}${changelist}-JENKINS67693-${timestamp}</version>
     <description>Send build artifacts over SSH</description>
     <url>https://github.com/jenkinsci/publish-over-ssh-plugin</url>
-
-    <properties>
-        <revision>1.25</revision>
-        <changelist>-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/publish-over-ssh-plugin</gitHubRepo>
-        <jenkins.version>2.289.1</jenkins.version>
-        <java.level>8</java.level>
-    </properties>
 
     <licenses>
         <license>
@@ -89,6 +104,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
         </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.13.0</version>
+      </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,19 +25,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>9</source>
-                    <target>9</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshClient.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshClient.java
@@ -200,14 +200,16 @@ public class BapSshClient extends BPDefaultClient<BapSshTransfer> {
     public void transferFile(final BapSshTransfer bapSshTransfer, final FilePath filePath,
                              final InputStream inputStream) throws SftpException {
 
-        buildInfo.printIfVerbose(Messages.console_put(filePath.getName()));
         if( !isAvoidSameFileUpload() || remoteResourceCache.checkCachedResource(filePath) ) {
+          buildInfo.printIfVerbose(Messages.console_put(filePath.getName()));
           sftp.put(inputStream, filePath.getName());
           success();
         }
         else
         {
-          buildInfo.printIfVerbose(Messages._console_warning( Messages.console_message_transferskip() ).toString());
+          buildInfo.println(Messages._console_warning(
+            Messages.console_message_transferskip(filePath.getName()) )
+            .toString());
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
@@ -1,0 +1,140 @@
+package jenkins.plugins.publish_over_ssh;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BapSshTransferCache {
+  private static final String CACHEFILENAME = "remoteResourceCache.json";
+  private HashMap<String, BapSshTransferCacheRow> data;
+  private File configFile;
+  private FilePath.FileCallable<File> callableFile;
+  public BapSshTransferCache(FilePath configPath) {
+    try {
+      callableFile = new FilePath.FileCallable<>() {
+        @Override
+        public File invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
+          return file;
+        }
+        @Override
+        public void checkRoles(RoleChecker roleChecker) throws SecurityException {}
+      };
+
+      configFile = configPath.child(CACHEFILENAME).act(callableFile);
+
+      ObjectMapper mapper = new ObjectMapper();
+      data = mapper.readValue(configFile, new TypeReference<HashMap<String, BapSshTransferCacheRow>>() {});
+    }
+    catch ( IOException | InterruptedException ex )
+    {
+      data = new HashMap<>();
+    }
+  }
+
+  public void save() {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      mapper.writeValue(configFile, data);
+    }
+    catch ( IOException ex )
+    {
+      data = null;
+    }
+  }
+
+  public boolean checkCachedResource( FilePath filePath ) {
+    try {
+      File resource = filePath.act(callableFile);
+      if( !data.containsKey(resource.getAbsolutePath()) ) {
+        data.put( resource.getAbsolutePath(), new BapSshTransferCacheRow(resource) );
+        return true;
+      }
+
+      BapSshTransferCacheRow resourceEntry = data.get(resource.getAbsolutePath());
+      return resourceEntry.mustUpdateWith( resource );
+    }
+    catch ( IOException | InterruptedException ex )
+    {
+      data = new HashMap<>();
+      configFile = new File( CACHEFILENAME ); // todo check
+    }
+
+    return false;
+  }
+}
+
+class BapSshTransferCacheRow {
+  public byte[] HashValue;
+  public long   LastAccess;
+
+  public BapSshTransferCacheRow() {
+    // For deserialization with Jackson library
+  }
+
+  public BapSshTransferCacheRow(File fileRef) {
+    HashValue = getHashValue(fileRef);
+    try {
+      LastAccess = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
+    }
+    catch (IOException ex) {
+      LastAccess = 0;
+    }
+  }
+
+  private byte[] getHashValue(File fileRef) {
+    try {
+      byte[] tmpBuffer = new byte[8192];
+
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      try (InputStream is = Files.newInputStream(fileRef.toPath());
+           DigestInputStream dis = new DigestInputStream(is, md))
+      {
+        while (dis.available() > 0) {
+          dis.read(tmpBuffer, 0, 8192);
+        }
+      }
+      return md.digest();
+    }
+    catch (IOException | NoSuchAlgorithmException ex) {
+      return null;
+    }
+  }
+
+  public boolean mustUpdateWith(File fileRef) {
+    try {
+      long newAccessTime = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
+      if (newAccessTime <= LastAccess)
+        return false;
+    }
+    catch (IOException ex)
+    {
+      return false;
+    }
+
+    byte[] newHashValue = getHashValue(fileRef);
+    if( Arrays.equals( HashValue, newHashValue ) )
+      return false;
+
+    try {
+      LastAccess = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
+    }
+    catch (IOException ex) {
+      LastAccess = 0;
+    }
+    HashValue = newHashValue;
+    return true;
+  }
+}

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
@@ -15,8 +15,24 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
 
+/**
+ * This class allows to handle the tracking of the files transferred to the
+ * remote servers so that those upload can be skipped if possible.
+ *
+ * The files are tracked via a per-job json cache file ("remoteResourceCache.json")
+ * which contains a map of the absolute paths of the uploaded files and the values:
+ * * Last access timestamp
+ * * MD5 Hash value
+ *
+ * The files are signaled to be uploaded in two scenarios:
+ * * They were not uploaded previously, they are now tracked and uploaded
+ * * They were already uploaded before, only if the file has newer access timestamp and a *different* MD5 value they are uploaded
+ *
+ * This is done for performance reasons, large files may take a long time to compute the MD5 hash
+ * so if they are not newer then there is no need to compute it because we already know that the upload
+ * will be rejected.
+ */
 public class BapSshTransferCache {
   private static final String CACHEFILENAME = "remoteResourceCache.json";
   private HashMap<String, BapSshTransferCacheRow> data;
@@ -44,6 +60,9 @@ public class BapSshTransferCache {
     }
   }
 
+  /**
+   * Writes the current memory data to the cache file as JSON
+   */
   public void save() {
     try {
       ObjectMapper mapper = new ObjectMapper();
@@ -55,45 +74,72 @@ public class BapSshTransferCache {
     }
   }
 
+  /**
+   * Checks if the resources indicated by the FilePath instance
+   * should be uploaded or not according to the cache
+   *
+   * @param filePath  path of the resource
+   * @return true if the resource shall be uploaded, false otherwise
+   */
   public boolean checkCachedResource( FilePath filePath ) {
     try {
       File resource = filePath.act(callableFile);
       if( !data.containsKey(resource.getAbsolutePath()) ) {
+        // the resource is tracked already, register it and let i upload
         data.put( resource.getAbsolutePath(), new BapSshTransferCacheRow(resource) );
         return true;
       }
 
+      // the resource was already tracked, check it with the cached data
       BapSshTransferCacheRow resourceEntry = data.get(resource.getAbsolutePath());
       return resourceEntry.mustUpdateWith( resource );
     }
     catch ( IOException | InterruptedException ex )
     {
       data = new HashMap<>();
-      configFile = new File( CACHEFILENAME ); // todo check
+      configFile = new File( CACHEFILENAME );
     }
 
+    // in case of exception than reject the upload
     return false;
   }
 }
 
+/**
+ * Class that tracks a single resources' values in the cache
+ */
 class BapSshTransferCacheRow {
   public byte[] HashValue;
-  public long   LastAccess;
+  public long LastModified;
 
-  public BapSshTransferCacheRow() {
-    // For deserialization with Jackson library
-  }
+  /**
+   * For deserialization compatibility with Jackson library
+   * the fields are automatically serialized/deserialized
+    */
+  public BapSshTransferCacheRow() {}
 
+  /**
+   * Used to explicitly initialize a resource in the cache with
+   * it's current values of md5 hash and last modified time
+   *
+   * @param fileRef
+   */
   public BapSshTransferCacheRow(File fileRef) {
     HashValue = getHashValue(fileRef);
     try {
-      LastAccess = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
+      LastModified = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
     }
     catch (IOException ex) {
-      LastAccess = 0;
+      LastModified = 0;
     }
   }
 
+  /**
+   * Calculates the MD5 hash value of a file
+   *
+   * @param fileRef file to be hashed
+   * @return byte array of the file's hash, null in case of error
+   */
   private byte[] getHashValue(File fileRef) {
     try {
       byte[] tmpBuffer = new byte[8192];
@@ -113,11 +159,22 @@ class BapSshTransferCacheRow {
     }
   }
 
+  /**
+   * Checks if the current instance has to be updated with the file indicated.
+   * Returns true if both:
+   * * last modified time for the input file is newer than the tracked one
+   * * MD5 hash of the input file is different than the tracked one
+   *
+   * For performance reasons if the modified time checks fails, no hash is computed.
+   *
+   * @param fileRef  file to check
+   * @return  true if the input file updated the row
+   */
   public boolean mustUpdateWith(File fileRef) {
     try {
-      long newAccessTime = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
-      if (newAccessTime <= LastAccess)
-        return false;
+      long newModifiedTime = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
+      if (newModifiedTime <= LastModified)
+        return false; // input files is older / current with tracked one, do not upload
     }
     catch (IOException ex)
     {
@@ -126,15 +183,16 @@ class BapSshTransferCacheRow {
 
     byte[] newHashValue = getHashValue(fileRef);
     if( Arrays.equals( HashValue, newHashValue ) )
-      return false;
+      return false; // file is newer but hash is the same, don't upload
 
+    // Here both conditions are true so update the tracked data
     try {
-      LastAccess = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
+      LastModified = Files.getLastModifiedTime(fileRef.toPath()).toMillis();
     }
     catch (IOException ex) {
-      LastAccess = 0;
+      LastModified = 0;
     }
     HashValue = newHashValue;
-    return true;
+    return true; // Let the file be uploaded
   }
 }

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
@@ -36,7 +36,7 @@ public class BapSshTransferCache {
       configFile = configPath.child(CACHEFILENAME).act(callableFile);
 
       ObjectMapper mapper = new ObjectMapper();
-      data = mapper.readValue(configFile, new TypeReference<HashMap<String, BapSshTransferCacheRow>>() {});
+      data = mapper.readValue(configFile, new TypeReference<>() {});
     }
     catch ( IOException | InterruptedException ex )
     {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshTransferCache.java
@@ -40,7 +40,7 @@ public class BapSshTransferCache {
   private FilePath.FileCallable<File> callableFile;
   public BapSshTransferCache(FilePath configPath) {
     try {
-      callableFile = new FilePath.FileCallable<>() {
+      callableFile = new FilePath.FileCallable<File>() {
         @Override
         public File invoke(File file, VirtualChannel virtualChannel) throws IOException, InterruptedException {
           return file;
@@ -52,7 +52,7 @@ public class BapSshTransferCache {
       configFile = configPath.child(CACHEFILENAME).act(callableFile);
 
       ObjectMapper mapper = new ObjectMapper();
-      data = mapper.readValue(configFile, new TypeReference<>() {});
+      data = mapper.readValue(configFile, new TypeReference<HashMap<String, BapSshTransferCacheRow>>() {});
     }
     catch ( IOException | InterruptedException ex )
     {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshHostConfigurationDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshHostConfigurationDescriptor.java
@@ -61,6 +61,10 @@ public class BapSshHostConfigurationDescriptor extends Descriptor<BapSshHostConf
         return BapSshHostConfiguration.DEFAULT_TIMEOUT;
     }
 
+    public boolean getDefaultAvoidSameFileUploads() {
+      return BapSshHostConfiguration.DEFAULT_AVOID_SAME_FILES_UPLOAD;
+    }
+
     public FormValidation doCheckName(@QueryParameter final String value) {
         return BPValidators.validateName(value);
     }

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config.jelly
@@ -40,6 +40,9 @@
     <f:entry title="${m.remotePath()}" field="remoteRootDir">
         <f:textbox/>
     </f:entry>
+    <f:entry title="${%avoidSameFileUploads}" field="avoidSameFileUploads">
+        <f:checkbox default="${descriptor.defaultAvoidSameFileUploads}" />
+    </f:entry>
 
     <f:advanced>
 
@@ -89,7 +92,7 @@
         <f:entry title="${%proxyPassword}" field="secretProxyPassword">
             <f:password/>
         </f:entry>
-        
+
     </f:advanced>
 
     <f:validateButton title="${m.test_title()}" progress="${m.test_progress()}" method="testConnection"

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config.properties
@@ -36,3 +36,4 @@ proxyHost=Proxy host
 proxyPort=Proxy port
 proxyUser=Proxy user
 proxyPassword=Proxy password
+avoidSameFileUploads=Avoid sending files that have not changed

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config_no_BV.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config_no_BV.properties
@@ -36,3 +36,4 @@ proxyHost=P*o*y h*s*
 proxyPort=P*o*y p*r*
 proxyUser=P*o*y u*e*
 proxyPassword=P*o*y p*s*w*r*
+avoidSameFileUploads=A*o*d s*n*i*g f*l*s t*a* h*v* n*t c*a*g*d

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/help-avoidSameFileUploads.html
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/help-avoidSameFileUploads.html
@@ -1,0 +1,5 @@
+
+<div>
+<p>Avoids to send files to remote target if they are still the same.</p>
+<p>Based on checking last modification time and MD5 hash of the resource to be uploaded</p>
+</div>

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
@@ -41,7 +41,7 @@ publisherLabel.descriptor.displayName=SSH Publisher Label
 global.common.descriptor=SSH Common Configuration
 global.hostconfig.descriptor=SSH Host Configuration
 
-console.message.prefix=SSH:
+console.message.prefix=SSH: 
 console.message.transferskip=Transfer {0} skipped
 console.session.creating=Creating session: username [{0}], hostname [{1}], port [{2}]
 console.session.connecting=Connecting session ...

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
@@ -41,7 +41,8 @@ publisherLabel.descriptor.displayName=SSH Publisher Label
 global.common.descriptor=SSH Common Configuration
 global.hostconfig.descriptor=SSH Host Configuration
 
-console.message.prefix=SSH: 
+console.message.prefix=SSH:
+console.message.transferskip=Transfer skipped
 console.session.creating=Creating session: username [{0}], hostname [{1}], port [{2}]
 console.session.connecting=Connecting session ...
 console.session.connected=Connected
@@ -61,6 +62,7 @@ console.cd=cd [{0}]
 console.mkdir=mkdir [{0}]
 console.put=put [{0}]
 console.success=OK
+console.warning=WARNING: Message [{0}]
 console.failure=FAILED: Message [{0}]
 
 sftpExec.unsupportedCommand=Unsupported command [{0}]

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
@@ -41,7 +41,7 @@ publisherLabel.descriptor.displayName=SSH Publisher Label
 global.common.descriptor=SSH Common Configuration
 global.hostconfig.descriptor=SSH Host Configuration
 
-console.message.prefix=SSH:
+console.message.prefix=SSH: 
 console.message.transferskip=Transfer skipped
 console.session.creating=Creating session: username [{0}], hostname [{1}], port [{2}]
 console.session.connecting=Connecting session ...

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/Messages.properties
@@ -41,8 +41,8 @@ publisherLabel.descriptor.displayName=SSH Publisher Label
 global.common.descriptor=SSH Common Configuration
 global.hostconfig.descriptor=SSH Host Configuration
 
-console.message.prefix=SSH: 
-console.message.transferskip=Transfer skipped
+console.message.prefix=SSH:
+console.message.transferskip=Transfer {0} skipped
 console.session.creating=Creating session: username [{0}], hostname [{1}], port [{2}]
 console.session.connecting=Connecting session ...
 console.session.connected=Connected

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/Messages_no_BV.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/Messages_no_BV.properties
@@ -41,7 +41,7 @@ publisherLabel.descriptor.displayName=S*H P*b*i*h*r L*b*l
 global.common.descriptor=S*H C*m*o* C*n*i*u*a*i*n
 global.hostconfig.descriptor=S*H H*s* C*n*i*u*a*i*n
 
-console.message.prefix=S*H: 
+console.message.prefix=S*H:
 console.session.creating=C*e*t*n* s*s*i*n: u*e*n*m* [{0}], h*s*n*m* [{1}], p*r* [{2}]
 console.session.connecting=C*n*e*t*n* s*s*i*n ...
 console.session.connected=C*n*e*t*d
@@ -61,6 +61,7 @@ console.cd=cd [{0}]
 console.mkdir=mkdir [{0}]
 console.put=put [{0}]
 console.success=O*
+console.warning=W*R*I*G: M*s*a*e [{0}]
 console.failure=F*I*E*: M*s*a*e [{0}]
 
 exception.badTransferConfig=A* S*H T*a*s*e* S*t m*s* n*t h*v* a* e*p*y S*u*c* f*l*s a*d a* e*p*y E*e* c*m*a*d - t*e t*a*s*e* s*t s*o*l* t*a*s*e* f*l*s, e*e*u*e a c*m*a*d o* d* b*t*

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults/config.jelly
@@ -27,7 +27,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:poj="/pojelly">
 
     <poj:defaultMessages/>
-    
+
     <f:entry title="${m.sourceFiles()}" field="sourceFiles">
         <f:textbox default="${defaults.transfer.sourceFiles}"/>
     </f:entry>
@@ -69,5 +69,8 @@
     </f:entry>
     <f:entry title="${m.cleanRemote()}" field="cleanRemote">
         <f:checkbox default="${defaults.transfer.cleanRemote}"/>
+    </f:entry>
+    <f:entry title="${%avoidSameFileUploads}" field="avoidSameFileUploads">
+        <f:checkbox default="${defaults.transfer.avoidSameFileUploads}"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults/config.properties
@@ -26,3 +26,4 @@ execCommand=Exec command
 execTimeout=Exec timeout (ms)
 usePty=Exec in pty
 useAgentForwarding=Exec using Agent Forwarding
+avoidSameFileUploads=Avoid sending files that have not changed

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults/config_no_BV.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/options/SshOverrideTransferDefaults/config_no_BV.properties
@@ -25,3 +25,4 @@
 execCommand=E*e* c*m*a*d
 execTimeout=E*e* t*m*o*t (m*)
 usePty=C*e*t* * *s*u*o*t*y
+avoidSameFileUploads=A*o*d s*n*i*g *i*e* t*a* h*v* c*a*g*d

--- a/src/test/java/jenkins/plugins/publish_over_ssh/BapSshClientTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/BapSshClientTest.java
@@ -91,14 +91,14 @@ public class BapSshClientTest {
     }
 
     @Test public void testGetSession() {
-        assertEquals(mockSession, bapSshClient.getSession());        
+        assertEquals(mockSession, bapSshClient.getSession());
     }
-    
+
     @Test public void testAddSession() {
         bapSshClient.addSession(mockSession2);
         assertEquals(mockSession2, bapSshClient.getSession());
     }
-    
+
     @Test public void testChangeDirectory() throws Exception {
         testHelper.expectDirectoryCheck(DIRECTORY_PATH, true);
         mockSftp.cd(DIRECTORY_PATH);
@@ -184,7 +184,7 @@ public class BapSshClientTest {
         mockSession.disconnect();
         assertDisconnect();
     }
-    
+
     @Test public void testDisconnectNotConnected() throws Exception {
         mockControl.checkOrder(false);
         expect(mockSftp.isConnected()).andReturn(false);
@@ -312,7 +312,7 @@ public class BapSshClientTest {
 
     @Test public void testBeginTransfersFailIfNoSourceFilesWhenExecDisabled() throws Exception {
         try {
-            final BapSshClient noExecBapSshClient = new BapSshClient(buildInfo, mockSession, true);
+            final BapSshClient noExecBapSshClient = new BapSshClient(buildInfo, mockSession, true, false);
             noExecBapSshClient.setSftp(mockSftp);
             final int execTimeout = 10000;
             noExecBapSshClient.beginTransfers(new BapSshTransfer("", "", "", false, false, "something to exec", execTimeout));
@@ -385,7 +385,7 @@ public class BapSshClientTest {
     }
 
      @Test public void testEndTransfersDoesNothingIfExecDisabled() throws Exception {
-        final BapSshClient noExecBapSshClient = new BapSshClient(buildInfo, mockSession, true);
+        final BapSshClient noExecBapSshClient = new BapSshClient(buildInfo, mockSession, true, false);
         noExecBapSshClient.setSftp(mockSftp);
         final int execTimeout = 10000;
         mockControl.replay();


### PR DESCRIPTION
[fixes #65]

It introduces the requested feature by which it is now possible to activate a configuration item under the SSH Host page (disabled by default) that will track the selected files for upload and check if it is really necessary to upload it again.

The tracking is done in a json file in job-specific folder and two values are tracked for every file:
* Last modified timestamp
* MD5 hash

The files are uploaded only if either:
* The file was not previously uploaded
* The new file timestamp is newer AND the MD5 hash has changed

As an optimization if the timestamp is not newer than the MD5 hash is not recomputed (which could be slow for big files).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
