### PR TITLE
Dynamic and flexible definition of an Alternative Hostname

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
@@ -50,7 +50,7 @@ public class BapSshCredentials extends BapSshKeyInfo implements Credentials<BapS
     }
 
     public BapSshCredentialsDescriptor getDescriptor() {
-        return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshCredentialsDescriptor.class);
+        return Jenkins.getInstance().getDescriptorByType(BapSshCredentialsDescriptor.class);
     }
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshCredentials that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshCredentials.java
@@ -50,7 +50,7 @@ public class BapSshCredentials extends BapSshKeyInfo implements Credentials<BapS
     }
 
     public BapSshCredentialsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(BapSshCredentialsDescriptor.class);
+        return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshCredentialsDescriptor.class);
     }
 
     protected EqualsBuilder addToEquals(final EqualsBuilder builder, final BapSshCredentials that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration.java
@@ -263,20 +263,20 @@ public class BapSshHostConfiguration extends BPHostConfiguration<BapSshClient, B
     @Override
     public BapSshClient createClient(final BPBuildInfo buildInfo, final BapPublisher publisher) {
         if(publisher instanceof BapSshPublisher) {
-            return createClient(buildInfo, ((BapSshPublisher) publisher).isSftpRequired());
+            return createClient(buildInfo, ((BapSshPublisher) publisher).isSftpRequired(), ((BapSshPublisher) publisher).getOverrideHostnameOrNull());
         }
         throw new IllegalArgumentException("Invalid type passed to createClient");
     }
 
     @Override
     public BapSshClient createClient(final BPBuildInfo buildInfo) {
-        return createClient(buildInfo, true);
+        return createClient(buildInfo, true, null);
     }
 
-    public BapSshClient createClient(final BPBuildInfo buildInfo, final boolean connectSftp) {
+    public BapSshClient createClient(final BPBuildInfo buildInfo, final boolean connectSftp, final String overrideHostname) {
 
         final JSch ssh = createJSch();
-        String[] hosts = getHosts();
+        String[] hosts = getHosts(overrideHostname);
         Session session = createSession(buildInfo, ssh, hosts[0], getPort());
         configureAuthentication(buildInfo, ssh, session);
         final BapSshClient bapClient = new BapSshClient(buildInfo, session, isEffectiveDisableExec(), isAvoidSameFileUploads());
@@ -300,11 +300,16 @@ public class BapSshHostConfiguration extends BPHostConfiguration<BapSshClient, B
 
     /**
      * create a list of hosts from the explicit stated target host and an optional list of jumphosts
+     * @param overrideHostname 
      *
      * @return list of hosts
      */
-    String[] getHosts() {
-        return HostsHelper.getHosts(getHostnameTrimmed(), jumpHost);
+    String[] getHosts(String overrideHostname) {
+    	if(overrideHostname == null) {
+    		return HostsHelper.getHosts(getHostnameTrimmed(), jumpHost);
+    	} else {
+    		return new String[] {overrideHostname};
+    	}
     }
 
     static class HostsHelper {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname.java
@@ -49,7 +49,7 @@ public class BapSshOverrideHostname implements Describable<BapSshOverrideHostnam
 	}
 
 	public Descriptor<BapSshOverrideHostname> getDescriptor() {
-		return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshOverrideHostnameDescriptor.class);
+		return Jenkins.getInstance().getDescriptorByType(BapSshOverrideHostnameDescriptor.class);
 	}
 
 }

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2010-2011 by Anthony Robinson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.publish_over_ssh;
+
+import java.io.Serializable;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+import jenkins.plugins.publish_over_ssh.descriptor.BapSshOverrideHostnameDescriptor;
+
+public class BapSshOverrideHostname implements Describable<BapSshOverrideHostname>, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String overrideHostname;
+
+	@DataBoundConstructor
+	public BapSshOverrideHostname(final String overrideHostname) {
+		this.overrideHostname = overrideHostname;
+	}
+
+	public String getOverrideHostname() {
+		return overrideHostname;
+	}
+
+	public Descriptor<BapSshOverrideHostname> getDescriptor() {
+		return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshOverrideHostnameDescriptor.class);
+	}
+
+}

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshParamPublish.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshParamPublish.java
@@ -45,7 +45,7 @@ public class BapSshParamPublish extends ParamPublish implements Describable<BapS
     }
 
     public BapSshParamPublishDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(BapSshParamPublishDescriptor.class);
+        return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshParamPublishDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshParamPublish.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshParamPublish.java
@@ -45,7 +45,7 @@ public class BapSshParamPublish extends ParamPublish implements Describable<BapS
     }
 
     public BapSshParamPublishDescriptor getDescriptor() {
-        return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshParamPublishDescriptor.class);
+        return Jenkins.getInstance().getDescriptorByType(BapSshParamPublishDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisher.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisher.java
@@ -82,7 +82,7 @@ public class BapSshPublisher extends BapPublisher<BapSshTransfer> implements Des
     }
 
     public BapSshPublisherDescriptor getDescriptor() {
-        return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshPublisherDescriptor.class);
+        return Jenkins.getInstance().getDescriptorByType(BapSshPublisherDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisher.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/BapSshPublisher.java
@@ -44,11 +44,14 @@ public class BapSshPublisher extends BapPublisher<BapSshTransfer> implements Des
 
     private static final long serialVersionUID = 1L;
 
+    private BapSshOverrideHostname overrideHostname;
+    
     @DataBoundConstructor
     public BapSshPublisher(final String configName, final boolean verbose, final ArrayList<BapSshTransfer> transfers,
                            final boolean useWorkspaceInPromotion, final boolean usePromotionTimestamp, final BapSshRetry sshRetry,
-                           final BapSshPublisherLabel sshLabel, final BapSshCredentials sshCredentials) {
+                           final BapSshPublisherLabel sshLabel, final BapSshCredentials sshCredentials, final BapSshOverrideHostname sshOverrideHostname) {
         super(configName, verbose, transfers, useWorkspaceInPromotion, usePromotionTimestamp, sshRetry, sshLabel, sshCredentials);
+        this.overrideHostname = sshOverrideHostname;
     }
 
     public final boolean isSftpRequired() {
@@ -69,9 +72,17 @@ public class BapSshPublisher extends BapPublisher<BapSshTransfer> implements Des
     public BapSshCredentials getSshCredentials() {
         return (BapSshCredentials) getCredentials();
     }
+    
+    public BapSshOverrideHostname getSshOverrideHostname() {
+        return overrideHostname;
+    }
+    
+    public String getOverrideHostnameOrNull() {
+        return (overrideHostname == null ? null : overrideHostname.getOverrideHostname());
+    }
 
     public BapSshPublisherDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(BapSshPublisherDescriptor.class);
+        return Jenkins.getInstanceOrNull().getDescriptorByType(BapSshPublisherDescriptor.class);
     }
 
     public boolean equals(final Object that) {

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshCredentialsDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshCredentialsDescriptor.java
@@ -24,6 +24,10 @@
 
 package jenkins.plugins.publish_over_ssh.descriptor;
 
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
@@ -35,11 +39,6 @@ import jenkins.plugins.publish_over.BPBuildInfo;
 import jenkins.plugins.publish_over_ssh.BapSshCredentials;
 import jenkins.plugins.publish_over_ssh.BapSshHostConfiguration;
 import jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.interceptor.RequirePOST;
-
-import java.io.IOException;
 
 @Extension
 public class BapSshCredentialsDescriptor extends Descriptor<BapSshCredentials> {
@@ -60,9 +59,9 @@ public class BapSshCredentialsDescriptor extends Descriptor<BapSshCredentials> {
     public FormValidation doCheckKeyPath(@QueryParameter final String value) {
         AccessControlled subject = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
         if (subject == null) {
-            subject = Jenkins.getInstance();
+            subject = Jenkins.getInstanceOrNull();
         }
-        if (!subject.hasPermission(Item.CONFIGURE)&&subject.hasPermission(Item.EXTENDED_READ)) {
+        if (subject != null && !subject.hasPermission(Item.CONFIGURE) && subject.hasPermission(Item.EXTENDED_READ)) {
             return FormValidation.ok();
         }
         return FormValidation.ok();

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshHostConfigurationDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshHostConfigurationDescriptor.java
@@ -96,7 +96,7 @@ public class BapSshHostConfigurationDescriptor extends Descriptor<BapSshHostConf
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         final BapSshPublisherPlugin.Descriptor pluginDescriptor;
-        Jenkins j = Jenkins.getInstanceOrNull();
+        Jenkins j = Jenkins.getInstance();
         if(j != null) {
             pluginDescriptor = j.getDescriptorByType(BapSshPublisherPlugin.Descriptor.class);
         }

--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshOverrideHostnameDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshOverrideHostnameDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2010-2011 by Anthony Robinson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.publish_over_ssh.descriptor;
+
+import org.kohsuke.stapler.QueryParameter;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import jenkins.plugins.publish_over_ssh.BapSshOverrideHostname;
+
+@Extension
+public class BapSshOverrideHostnameDescriptor extends Descriptor<BapSshOverrideHostname> {
+
+    public BapSshOverrideHostnameDescriptor() {
+        super(BapSshOverrideHostname.class);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "not seen";
+    }
+
+    public FormValidation doCheckHostname(@QueryParameter final String overrideHostname) {
+        return FormValidation.validateRequired(overrideHostname);
+    }
+
+
+
+}

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshHostConfiguration/config.jelly
@@ -45,7 +45,7 @@
     </f:entry>
 
     <f:advanced>
-
+    
         <f:optionalBlock inline="true" title="${%override.default.key}" field="overrideKey">
             <f:entry title="${%password}" field="encryptedPassword">
                 <f:password/>

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname/config.jelly
@@ -1,0 +1,35 @@
+<?jelly escape-by-default='true'?>
+
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (C) 2010-2011 by Anthony Robinson
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:poj="/pojelly">
+
+    <poj:defaultMessages/>
+    
+    <f:entry title="${%overrideHostname}" field="overrideHostname">
+        <f:textbox/>
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname/config.properties
@@ -22,17 +22,4 @@
 # THE SOFTWARE.
 #
 
-.idea/
-target/
-*.iml
-out/
-*~
-work/
-
-/target
-.settings/
-.classpath
-.project
-**/.DS_Store
-jenkins-cli.jar
-roundtrip.sh
+overrideHostname=Different Host

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname/help-overrideHostname.html
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshOverrideHostname/help-overrideHostname.html
@@ -1,0 +1,29 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (C) 2010-2011 by Anthony Robinson
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    <p>Select a different Hostname to connect to.</p>
+    <p>By chosing a different hostname its possible to dynamically change the server to reach out to without the need to change the Jenkins configuration.
+    </p>
+</div>

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/config.jelly
@@ -54,6 +54,9 @@
     </j:if>
 
     <f:advanced>
+    	
+    	<f:optionalProperty title="${%hostconfig.sshOverrideHostname}" field="sshOverrideHostname"/>
+    	
         <f:entry field="verbose">
             <poj:checkbox title="${m.verbose()}" default="${defaults.publisher.verbose}"/>
         </f:entry>

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/config.properties
@@ -23,3 +23,4 @@
 #
 
 hostconfig.noexec.suffix=\ [No Exec]
+hostconfig.sshOverrideHostname=Override Hostname

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/config_no_BV.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/config_no_BV.properties
@@ -23,3 +23,4 @@
 #
 
 hostconfig.noexec.suffix=\ [N* E*e*]
+hostConfig.sshOverrideHostname=O*r*e H*e

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/help-overrideHostname.html
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshPublisher/help-overrideHostname.html
@@ -1,0 +1,29 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (C) 2010-2011 by Anthony Robinson
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    Set an alternative Hostname.
+    <p>If you want to use different credentials from those configured for this server, or if the credentials have not been specified
+       for this server, then enable this option and set them here.</p>
+</div>

--- a/src/test/java/jenkins/plugins/publish_over_ssh/BapSshClientTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/BapSshClientTest.java
@@ -24,15 +24,20 @@
 
 package jenkins.plugins.publish_over_ssh;
 
-import com.jcraft.jsch.ChannelExec;
-import com.jcraft.jsch.ChannelSftp;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.SftpATTRS;
-import com.jcraft.jsch.SftpException;
-import hudson.FilePath;
-import jenkins.plugins.publish_over.BPBuildInfo;
-import jenkins.plugins.publish_over.BapPublisherException;
-import jenkins.plugins.publish_over_ssh.helper.BapSshTestHelper;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Vector;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.apache.commons.lang.SystemUtils;
 import org.easymock.classextension.EasyMock;
 import org.easymock.classextension.IMocksControl;
@@ -41,20 +46,16 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Objects;
-import java.util.Vector;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.SftpATTRS;
+import com.jcraft.jsch.SftpException;
 
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import hudson.FilePath;
+import jenkins.plugins.publish_over.BPBuildInfo;
+import jenkins.plugins.publish_over.BapPublisherException;
+import jenkins.plugins.publish_over_ssh.helper.BapSshTestHelper;
 
 @SuppressWarnings({ "PMD.SignatureDeclareThrowsException", "PMD.TooManyMethods" })
 public class BapSshClientTest {

--- a/src/test/java/jenkins/plugins/publish_over_ssh/BapSshHostConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/BapSshHostConfigurationTest.java
@@ -372,7 +372,7 @@ public class BapSshHostConfigurationTest {
         final BapSshTransfer transfer2 = new BapSshTransfer("", "", "", "", false, false, "pwd", 10000, false, false, false, false, null);
         final ArrayList<BapSshTransfer> transfers = new ArrayList<BapSshTransfer>();
         transfers.addAll(Arrays.asList(transfer1, transfer2));
-        final BapSshPublisher publisher = new BapSshPublisher(getHostConfig().getName(), false, transfers, false, false, null, null, null);
+        final BapSshPublisher publisher = new BapSshPublisher(getHostConfig().getName(), false, transfers, false, false, null, null, null, null);
         expect(mockJSch.getSession(getHostConfig().getUsername(), getHostConfig().getHostname(), getHostConfig().getPort())).andReturn(mockSession);
         mockSession.setPassword(defaultKeyInfo.getPassphrase());
         mockSession.setConfig((Properties) anyObject());

--- a/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/IntegrationTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/IntegrationTest.java
@@ -90,7 +90,7 @@ public class IntegrationTest {
         final int execTimeout = 10000;
         final BapSshTransfer transfer = new BapSshTransfer("**/*", null, "sub-home", dirToIgnore, false, false, "", execTimeout, false, false, false, false, null);
         final BapSshPublisher publisher = new BapSshPublisher(testHostConfig.getName(), false,
-                        new ArrayList<BapSshTransfer>(Collections.singletonList(transfer)), false, false, null, null, null);
+                        new ArrayList<BapSshTransfer>(Collections.singletonList(transfer)), false, false, null, null, null, null);
         final BapSshPublisherPlugin plugin = new BapSshPublisherPlugin(
                         new ArrayList<BapSshPublisher>(Collections.singletonList(publisher)), false, false, false, "master", null);
 

--- a/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/LegacyConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_ssh/jenkins/LegacyConfigurationTest.java
@@ -246,7 +246,7 @@ public class LegacyConfigurationTest {
     }
 
     private static BapSshPublisher newPublisher(final String configName, final boolean verbose, final ArrayList<BapSshTransfer> transfers) {
-        return new BapSshPublisher(configName, verbose, transfers, false, false, null, null, null);
+        return new BapSshPublisher(configName, verbose, transfers, false, false, null, null, null, null);
     }
 
 }


### PR DESCRIPTION
My motivation for this PR is to change the static way how hosts are defined. At the moment its required to change the main Jenkins configuration, which requires admin permissions and requires a restart to take effect.

In our projects we would like to be more dynamic on spawning new server instances and more flexible on job creation. Therefore it is required to override/define the hostname inside a build definition.

Let me know what you think, what should be changed and can be made better.