### PR TITLE
[JENKINS-74018] Migrate legacy `checkUrl` attributes in `BapSshTransfer/config.jelly`

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshTransferDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ssh/descriptor/BapSshTransferDescriptor.java
@@ -53,26 +53,26 @@ public class BapSshTransferDescriptor extends Descriptor<BapSshTransfer> {
         return FormValidation.validateNonNegativeInteger(value);
     }
 
-    public FormValidation doCheckSourceFiles(@QueryParameter final String configName, @QueryParameter final String sourceFiles,
+    public FormValidation doCheckSourceFiles(@QueryParameter final String sourceFilesConfigName, @QueryParameter final String value,
                                              @QueryParameter final String execCommand) {
-        if (Util.fixEmptyAndTrim(configName) != null) {
+        if (Util.fixEmptyAndTrim(sourceFilesConfigName) != null) {
             final BapSshPublisherPlugin.Descriptor pluginDescriptor = Jenkins.getActiveInstance().getDescriptorByType(
                     BapSshPublisherPlugin.Descriptor.class);
-            final BapSshHostConfiguration hostConfig = pluginDescriptor.getConfiguration(configName);
+            final BapSshHostConfiguration hostConfig = pluginDescriptor.getConfiguration(sourceFilesConfigName);
             if (hostConfig == null)
-                return FormValidation.error(Messages.descriptor_sourceFiles_check_configNotFound(configName));
+                return FormValidation.error(Messages.descriptor_sourceFiles_check_configNotFound(sourceFilesConfigName));
             if (hostConfig.isEffectiveDisableExec())
-                return FormValidation.validateRequired(sourceFiles);
+                return FormValidation.validateRequired(value);
         }
-        return checkTransferSet(sourceFiles, execCommand);
+        return checkTransferSet(value, execCommand);
     }
 
     public FormValidation doCheckPatternSeparator(@QueryParameter final String value) {
         return BPValidators.validateRegularExpression(value);
     }
 
-    public FormValidation doCheckExecCommand(@QueryParameter final String sourceFiles, @QueryParameter final String execCommand) {
-        return checkTransferSet(sourceFiles, execCommand);
+    public FormValidation doCheckExecCommand(@QueryParameter final String sourceFiles, @QueryParameter final String value) {
+        return checkTransferSet(sourceFiles, value);
     }
 
     private FormValidation checkTransferSet(final String sourceFiles, final String execCommand) {

--- a/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshTransfer/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ssh/BapSshTransfer/config.jelly
@@ -28,8 +28,11 @@
 
     <poj:defaultMessages/>
 
+    <f:invisibleEntry>
+      <f:textbox clazz="ssh-transfer-source-files-config-name" field="sourceFilesConfigName"/>
+    </f:invisibleEntry>
     <f:entry title="${m.sourceFiles()}" field="sourceFiles" help="${descriptor.getHelpFile((inPromotion and !matrixPromotion) ? 'sourceFilesForPromotion' : 'sourceFiles')}">
-        <f:textbox checkUrl="'${rootURL}/descriptorByName/jenkins.plugins.publish_over_ssh.BapSshTransfer/checkSourceFiles'+qs(this).nearBy('sourceFiles').nearBy('execCommand').toString()+bap_get_configName_qs(this)" default="${defaults.transfer.sourceFiles}"/>
+        <f:textbox default="${defaults.transfer.sourceFiles}"/>
     </f:entry>
 
     <f:entry title="${m.removePrefix()}" field="removePrefix">
@@ -41,7 +44,7 @@
     </f:entry>
 
     <f:entry title="${%execCommand}" field="execCommand">
-        <poj:textarea checkUrl="'${rootURL}/descriptorByName/jenkins.plugins.publish_over_ssh.BapSshTransfer/checkExecCommand'+qs(this).nearBy('sourceFiles').nearBy('execCommand').toString()" minRows="1" class="ssh-exec-control" default="${defaults.transfer.execCommand}"/>
+        <f:textarea class="ssh-exec-control" default="${defaults.transfer.execCommand}"/>
     </f:entry>
 
     <f:description>

--- a/src/main/webapp/js/pos.js
+++ b/src/main/webapp/js/pos.js
@@ -102,8 +102,20 @@ var sshBehave = {
                 bap_show_exec_controls(publisher);
             }
             bap_blur_inputs(publisher);
+            updateSourceFilesConfigName(configName);
         };
     }
 };
 
 Behaviour.register(sshBehave);
+
+function updateSourceFilesConfigName(configNameElement) {
+    const parentContainer = configNameElement.closest("div[name='publishers']");
+    parentContainer.querySelectorAll(".ssh-transfer-source-files-config-name").forEach(function(hiddenField) {
+        hiddenField.value = configNameElement.value;
+    });
+}
+
+Behaviour.specify(".ssh-transfer-source-files-config-name", "SshTransfer_syncSourceFileConfigName", 0, function(element) {
+    element.value = element.closest("div[name='publishers']").querySelector("select.ssh-config-name").value;
+});

--- a/src/main/webapp/js/pos.js
+++ b/src/main/webapp/js/pos.js
@@ -111,11 +111,11 @@ Behaviour.register(sshBehave);
 
 function updateSourceFilesConfigName(configNameElement) {
     const parentContainer = configNameElement.closest("div[name='publishers']");
-    parentContainer.querySelectorAll(".ssh-transfer-source-files-config-name").forEach(function(hiddenField) {
+    parentContainer.querySelectorAll(".ssh-transfer-source-files-config-name").forEach(function (hiddenField) {
         hiddenField.value = configNameElement.value;
     });
 }
 
-Behaviour.specify(".ssh-transfer-source-files-config-name", "SshTransfer_syncSourceFileConfigName", 0, function(element) {
+Behaviour.specify(".ssh-transfer-source-files-config-name", "SshTransfer_syncSourceFileConfigName", 0, function (element) {
     element.value = element.closest("div[name='publishers']").querySelector("select.ssh-config-name").value;
 });


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74018

* Removed `checkUrl` attribute from the affected fields and renamed the parameter names in validation methods to let [CheckMethod](https://github.com/jenkinsci/jenkins/blob/7006cded64f63f788ae91dd7b7587a4a39e70273/core/src/main/java/hudson/util/FormValidation.java#L625-L727) do all the work.
* Replaced `poj:textarea` with `f:textarea`. `poj:textarea` is provided by https://plugins.jenkins.io/publish-over/ which had it's last release 7 years ago. It doesn't have some of the attributes that modern `f:textarea` has, and also stands out visually from the rest of the fields. This change is probably not needed for the form validation to work properly without `checkUrl` attribute, I haven't checked. Let me know if I should revert this to keep the PR clean.

### Testing done

Configure an SSH server on the Global Configuration page. Create a new freestyle job, in the Environment section check "Send files or execute commands over SSH before the build starts". In Transfer Set section fill Source files and Exec command fields to trigger the affected validation methods.

[Before the change](https://www.youtube.com/watch?v=U7kVE9mTWwQ)
[After the change](https://www.youtube.com/watch?v=OVaxIkCOI28)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
