### PR TITLE
Test with Java 25

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.8</version>
+    <version>1.13</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'linux', jdk: 25],
+  [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.9</version>
+        <version>5.28</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3850.vb_c5319efa_e29</version>
+                <version>5054.v620b_5d2b_d5e6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
 
   <artifactId>publish-over-ssh</artifactId>


### PR DESCRIPTION
## Test with Java 25

Java 25 released September 16, 2025.  The Jenkins project wants to support Java 25 soon.  Compile and test on ci.jenkins.io with Java 25 and Java 21.

Intentionally continues to generate Java 17 byte code as configured by the plugin parent pom.

Does not compile or test with Java 17 on ci.jenkins.io any longer because we have found no issues in the past that were specific to the Java 17 compiler.  The plan is to drop support for Java 17 in the not too distant future so that the Jenkins project is only supporting two major Java versions at a time, Java 21 and Java 25.

Includes pull requests:

* https://github.com/jenkinsci/publish-over-ssh-plugin/pull/413
* https://github.com/jenkinsci/publish-over-ssh-plugin/pull/411
* https://github.com/jenkinsci/publish-over-ssh-plugin/pull/406

### Testing done

* Confirmed that automated tests pass with Java 25

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
