### PR TITLE
Update publish-over dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>publish-over</artifactId>
-            <version>0.22</version>
+            <version>240.v295a_8d2383f1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This plugin should now use the publish-over-plugin latest release 240.v295a_8d2383f1
